### PR TITLE
Get token from `gh` cli instead of from filesystem

### DIFF
--- a/tests/fixtures/gh_hosts.yml
+++ b/tests/fixtures/gh_hosts.yml
@@ -1,8 +1,0 @@
-github.example.com:
-  user: etopaxi
-  oauth_token: etopaxitesttoken
-  git_protocol: ssh
-github.com:
-  user: topaxi
-  oauth_token: topaxitesttoken
-  git_protocol: https

--- a/tests/github_spec.lua
+++ b/tests/github_spec.lua
@@ -6,7 +6,7 @@ describe("get_github_token", function()
   end)
 
   it("should read from gh/hosts.yml", function()
-    local token = gh.get_github_token("tests/fixtures/gh_hosts.yml")
+    local token = gh.get_github_token("echo etopaxitesttoken")
 
     assert.are.same("topaxitesttoken", token)
   end)
@@ -14,7 +14,7 @@ describe("get_github_token", function()
   it("should read from GITHUB_TOKEN", function()
     vim.env.GITHUB_TOKEN = "envtoken"
 
-    local token = gh.get_github_token("tests/fixtures/gh_hosts.yml")
+    local token = gh.get_github_token("echo etopaxitesttoken")
 
     assert.are.same("envtoken", token)
   end)


### PR DESCRIPTION
This updates the `get_github_token` fn to discover the authenticated user's auth token via the `gh auth token` cli command instead of by reading the token from `$HOME/.config/gh/hosts.yml` which doesn't contain the token in all scenarios.

Fixes #1