### PR TITLE
Fix duplicate icon in lualine component

### DIFF
--- a/lua/lualine/components/gh-actions.lua
+++ b/lua/lualine/components/gh-actions.lua
@@ -48,8 +48,7 @@ function component:update_status()
     return ''
   end
 
-  return self.options.icon
-    .. icons().get_workflow_run_icon(latest_workflow_run)
+  return icons().get_workflow_run_icon(latest_workflow_run)
     .. ' '
     .. latest_workflow_run.name
 end


### PR DESCRIPTION
Lualine puts the icon in for you, so returning it in the update status function caused the icon to duplicate. This fixes that.