### PR TITLE
Fix workflow dispatch - add yq compatibility switch and fix job creation

### DIFF
--- a/lua/gh-actions/git.lua
+++ b/lua/gh-actions/git.lua
@@ -2,7 +2,7 @@ local M = {}
 
 ---@param job Job
 local function create_job(job)
-  return require('plenary.job').job:new(job)
+  return require('plenary.job'):new(job)
 end
 
 function M.get_current_branch()

--- a/lua/gh-actions/yaml.lua
+++ b/lua/gh-actions/yaml.lua
@@ -17,7 +17,7 @@ function M.parse_yaml(yamlstr)
   if has_rust_module then
     return rust.parse_yaml(yamlstr or '')
   else
-    return vim.json.decode(vim.fn.system('yq', yamlstr))
+    return vim.json.decode(vim.fn.system({ 'yq', '-j' }, yamlstr))
   end
 end
 


### PR DESCRIPTION
The version of `yq` 4.x provided by homebrew on macOS when run without parameters does not convert Yaml to JSON as does the version 3.x on Ubuntu (it provides Yaml output instead). As `gh-actions` expects JSON, we need to force conversion. In previous attempt in #14 `-o=json` was used, but this is not supported by 3.x versions.

But it looks like all versions support `-j` with the same meaning.

However, on my systems (macOS, Linux) there is even earlier problem - execution of the job. So I provide a fix for this too.