### PR TITLE
Fix yq parsing for version 4.x

### DIFF
--- a/lua/gh-actions/yaml.lua
+++ b/lua/gh-actions/yaml.lua
@@ -17,7 +17,13 @@ function M.parse_yaml(yamlstr)
   if has_rust_module then
     return rust.parse_yaml(yamlstr or '')
   else
-    return vim.json.decode(vim.fn.system({ 'yq', '-j' }, yamlstr))
+    local result = vim
+      .system({ 'yq', '-j' }, {
+        stdin = yamlstr,
+        stderr = false,
+      })
+      :wait()
+    return vim.json.decode(result.stdout)
   end
 end
 


### PR DESCRIPTION
Apparently the depracation warning about `-j` does not get ignored, but mixed to the output. We have to use `vim.system` instead (Neovim 0.9+).