### PR TITLE
feat: support multiple remotes with interactive remote picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The pipeline.nvim plugin for Neovim allows developers to easily manage and dispa
 
 - List pipelines and their runs for the current repository
 - Run/dispatch pipelines with `workflow_dispatch`
+- Support for multiple remotes (e.g. `origin` + `upstream`)
 
 ## ToDo
 
@@ -70,6 +71,7 @@ Alternatively, if the [`glab`](https://docs.gitlab.com/ee/editor_extensions/gitl
 - `:Pipeline` or `:Pipeline toggle` toggles the `pipeline.nvim` split
 - `:Pipeline open` opens the `pipeline.nvim` split
 - `:Pipeline close` closes the `pipeline.nvim` split
+- `:Pipeline remote` opens a picker to switch the active remote
 
 ### Keybindings
 
@@ -79,6 +81,7 @@ The following keybindings are provided by the plugin:
 - `gp` - open the pipeline below the cursor on GitHub
 - `gr` - open the run below the cursor on GitHub
 - `gj` - open the job of the workflow run below the cursor on GitHub
+- `gR` - switch the active remote
 - `d` - dispatch a new run for the workflow below the cursor on GitHub
 
 ### Options

--- a/lua/lualine/components/pipeline.lua
+++ b/lua/lualine/components/pipeline.lua
@@ -35,13 +35,14 @@ function Component:init(options)
   self.store = require('pipeline.store')
   self.icons = require('pipeline.utils.icons')
 
-  local server, repo = require('pipeline.git').get_current_repository()
+  local pipeline = require('pipeline')
+  pipeline.setup_provider()
 
-  if not server or not repo then
+  if not pipeline.pipeline then
     return
   end
 
-  require('pipeline').start_polling()
+  pipeline.start_polling()
 
   self.store.on_update(function()
     require('lualine').refresh()

--- a/lua/pipeline/command.lua
+++ b/lua/pipeline/command.lua
@@ -18,6 +18,8 @@ local function handle_pipeline_command(a)
     return pipeline.close()
   elseif action == 'toggle' then
     return pipeline.toggle()
+  elseif action == 'remote' then
+    return pipeline.select_remote()
   end
 end
 
@@ -26,6 +28,7 @@ local function completion_customlist()
     'open',
     'close',
     'toggle',
+    'remote',
   }
 end
 

--- a/lua/pipeline/config.lua
+++ b/lua/pipeline/config.lua
@@ -59,7 +59,7 @@ local defaultConfig = {
   --- set to "current" to use the branch you're currently checked out
   --- set to any valid branch name to use that branch
   --- @type string
-  dispatch_branch = "default",
+  dispatch_branch = 'default',
   ---@class pipeline.config.Icons
   icons = {
     workflow_dispatch = '⚡️',
@@ -154,8 +154,8 @@ end
 
 function M.get_dispatch_branch()
   local git = require('pipeline.git')
-  return M.options.dispatch_branch == "default" and git.get_default_branch()
-    or M.options.dispatch_branch == "current" and git.get_current_branch()
+  return M.options.dispatch_branch == 'default' and git.get_default_branch()
+    or M.options.dispatch_branch == 'current' and git.get_current_branch()
     or M.options.dispatch_branch
 end
 

--- a/lua/pipeline/providers/github/rest/health.lua
+++ b/lua/pipeline/providers/github/rest/health.lua
@@ -6,7 +6,7 @@ function M.check()
   health.start('Github REST provider')
 
   local k, token, source =
-      pcall(require('pipeline.providers.github.utils').get_github_token)
+    pcall(require('pipeline.providers.github.utils').get_github_token)
 
   if k and token then
     if source == 'env' then

--- a/lua/pipeline/providers/github/rest/init.lua
+++ b/lua/pipeline/providers/github/rest/init.lua
@@ -153,8 +153,6 @@ function GithubRestProvider:dispatch(pipeline)
     return
   end
 
-  local store = require('pipeline.store')
-
   if pipeline then
     local Config = require('pipeline.config')
 

--- a/lua/pipeline/providers/github/rest/init.lua
+++ b/lua/pipeline/providers/github/rest/init.lua
@@ -1,10 +1,6 @@
 local utils = require('pipeline.utils')
 local Provider = require('pipeline.providers.polling')
 
-local function git()
-  return require('pipeline.git')
-end
-
 local function gh_api()
   return require('pipeline.providers.github.rest._api')
 end
@@ -21,36 +17,35 @@ local defaultOptions = {
 ---@field private repo string
 local GithubRestProvider = Provider:extend()
 
-function GithubRestProvider.detect()
+---@param remote pipeline.Remote
+---@return boolean
+function GithubRestProvider.detect(remote)
   if not utils.file_exists_in_git_root('.github/workflows') then
     return false
   end
 
   local Config = require('pipeline.config')
-  local server, repo = git().get_current_repository()
-  server = Config.resolve_host_for('github', server)
+  local server = Config.resolve_host_for('github', remote.server)
 
   if not Config.is_host_allowed(server) then
-    return
+    return false
   end
 
-  return server ~= nil and repo ~= nil
+  return server ~= nil and remote.repo ~= nil
 end
 
 ---@param opts pipeline.providers.github.rest.Options
-function GithubRestProvider:init(opts)
+---@param remote pipeline.Remote
+function GithubRestProvider:init(opts, remote)
   self.opts = vim.tbl_deep_extend('force', defaultOptions, opts)
 
   Provider.init(self, self.opts)
 
-  local server, repo = git().get_current_repository()
-
   local Config = require('pipeline.config')
-  self.server = Config.resolve_host_for('github', server)
-  self.repo = repo
+  self.server = Config.resolve_host_for('github', remote.server)
+  self.repo = remote.repo
 
   self.store.update_state(function(state)
-    state.title = string.format('Github Workflows for %s', repo)
     state.server = self.server
     state.repo = self.repo
   end)
@@ -161,8 +156,6 @@ function GithubRestProvider:dispatch(pipeline)
   local store = require('pipeline.store')
 
   if pipeline then
-    local server = store.get_state().server
-    local repo = store.get_state().repo
     local Config = require('pipeline.config')
 
     -- TODO should we get current ref instead or show an input with the
@@ -196,8 +189,8 @@ function GithubRestProvider:dispatch(pipeline)
         questions[i]:mount()
       else
         gh_api().dispatch_workflow(
-          server,
-          repo,
+          self.server,
+          self.repo,
           pipeline.pipeline_id,
           dispatch_branch,
           {

--- a/lua/pipeline/providers/gitlab/graphql/health.lua
+++ b/lua/pipeline/providers/gitlab/graphql/health.lua
@@ -8,11 +8,19 @@ function M.check()
 
   health.start('Gitlab GraphQL provider')
 
-  if utils.file_exists_in_git_root('.gitlab-ci.yml') then
-    local server = select(1, git.get_current_repository())
-    if server then
-      local host = Config.resolve_host_for('gitlab', server)
+  if not utils.file_exists_in_git_root('.gitlab-ci.yml') then
+    health.ok('Skipping GitLab auth check (no .gitlab-ci.yml)')
+    return
+  end
+
+  local remotes = git.get_remotes()
+  local found_gitlab = false
+
+  for _, remote in ipairs(remotes) do
+    if remote.server ~= Config.options.providers.github.default_host then
+      local host = Config.resolve_host_for('gitlab', remote.server)
       if Config.is_host_allowed(host) then
+        found_gitlab = true
         local k, token, source = pcall(
           require('pipeline.providers.gitlab.utils').get_gitlab_token,
           host
@@ -20,23 +28,32 @@ function M.check()
 
         if k and token then
           if source == 'env' then
-            health.ok('Found GitLab token in env')
+            health.ok(
+              string.format('Found GitLab token in env for %s', remote.name)
+            )
           elseif source == 'glab' then
-            health.ok('Found GitLab token via glab cli')
+            health.ok(
+              string.format(
+                'Found GitLab token via glab cli for %s',
+                remote.name
+              )
+            )
           else
-            health.ok('Found GitLab token')
+            health.ok(string.format('Found GitLab token for %s', remote.name))
           end
         else
-          health.error('No GitLab token found')
+          health.error(
+            string.format('No GitLab token found for %s', remote.name)
+          )
         end
       else
         health.warn('Host not allowed: ' .. host)
       end
-    else
-      health.warn('Unable to resolve gitlab host')
     end
-  else
-    health.ok('Skipping GitLab auth check (no .gitlab-ci.yml)')
+  end
+
+  if not found_gitlab then
+    health.warn('Unable to resolve gitlab host from any remote')
   end
 end
 

--- a/lua/pipeline/providers/provider.lua
+++ b/lua/pipeline/providers/provider.lua
@@ -37,7 +37,10 @@ function Provider:extend()
   return Class
 end
 
-function Provider.detect()
+---Detect whether this provider handles the given remote.
+---@param remote pipeline.Remote
+---@return boolean
+function Provider.detect(remote)
   vim.notify_once('Provider does not implement detect', vim.log.levels.WARN)
 
   return false
@@ -47,19 +50,21 @@ end
 ---@param config pipeline.Config
 ---@param store pipeline.Store
 ---@param opts? table
+---@param remote? pipeline.Remote
 ---@return self
-function Provider:new(config, store, opts)
+function Provider:new(config, store, opts, remote)
   local instance = setmetatable({}, self)
   instance.config = config
   instance.store = store
   instance.listener_count = 0
-  instance:init(opts or {})
+  instance:init(opts or {}, remote)
   return instance
 end
 
 ---Constructor function, called when creating a new Provider instance.
 ---@param opts table
-function Provider:init(opts) end
+---@param remote? pipeline.Remote
+function Provider:init(opts, remote) end
 
 ---Start fetching or listening to data from the provider.
 function Provider:connect() end

--- a/lua/pipeline/store.lua
+++ b/lua/pipeline/store.lua
@@ -5,7 +5,6 @@ local utils = require('pipeline.utils')
 ---@field config table
 
 ---@class pipeline.State
----@field title string
 ---@field repo string
 ---@field server string
 ---@field error string|nil
@@ -15,7 +14,6 @@ local utils = require('pipeline.utils')
 ---@field steps table<integer | string, pipeline.Step[]> Steps indexed by job id
 ---@field workflow_configs table<integer, pipeline.StatePipelineConfig>
 local initialState = {
-  title = 'pipeline.nvim',
   repo = '',
   server = '',
   error = nil,

--- a/lua/pipeline/ui/render.lua
+++ b/lua/pipeline/ui/render.lua
@@ -85,7 +85,11 @@ end
 --- Render title of the split window
 ---@param state pipeline.State
 function PipelineRender:title(state)
-  self:append(state.title):nl():nl()
+  local title = 'pipeline.nvim'
+  if state.repo and state.repo ~= '' then
+    title = string.format('Pipelines for %s', state.repo)
+  end
+  self:append(title):nl():nl()
 end
 
 --- Render error message

--- a/lua/pipeline/utils.lua
+++ b/lua/pipeline/utils.lua
@@ -93,14 +93,13 @@ function M.group_by(fn, tbl)
   return m
 end
 
-
 ---@param file string
 ---@return boolean
 function M.file_exists_in_git_root(file)
   local git_root_dir = vim.fn
     .fnamemodify(vim.trim(vim.fn.system('git rev-parse --show-toplevel')), ':p')
     :gsub('/$', '')
-  return vim.loop.fs_stat(git_root_dir .. "/" .. file) ~= nil
+  return vim.loop.fs_stat(git_root_dir .. '/' .. file) ~= nil
 end
 
 ---@param file string

--- a/tests/git_spec.lua
+++ b/tests/git_spec.lua
@@ -1,4 +1,4 @@
-describe('get_current_repository parsing', function()
+describe('parse_remote_url', function()
   local git = require('pipeline.git')
 
   local cases = {
@@ -31,10 +31,37 @@ describe('get_current_repository parsing', function()
 
   for _, case in ipairs(cases) do
     it('parses ' .. case.url, function()
-      local server, repo = git._parse_origin_url(case.url)
+      local server, repo = git._parse_remote_url(case.url)
 
       assert.are.same(case.server, server)
       assert.are.same(case.repo, repo)
     end)
   end
+
+  -- backwards-compat alias still works
+  it('exposes _parse_origin_url alias', function()
+    local server, repo =
+      git._parse_origin_url('git@github.com:some-org/some-repo.git')
+
+    assert.are.same('github.com', server)
+    assert.are.same('some-org/some-repo', repo)
+  end)
+end)
+
+describe('get_remotes', function()
+  local git = require('pipeline.git')
+
+  it('returns a list of pipeline.Remote entries', function()
+    -- get_remotes runs real git commands; in a real repo this returns at
+    -- least one entry.  We only validate the shape here since the actual
+    -- remote URLs depend on the test environment.
+    local remotes = git.get_remotes()
+    assert.is_table(remotes)
+
+    for _, remote in ipairs(remotes) do
+      assert.is_string(remote.name)
+      assert.is_string(remote.server)
+      assert.is_string(remote.repo)
+    end
+  end)
 end)


### PR DESCRIPTION
Instead of hardcoding `origin` we can now detect all configured Git remotes. Users with multiple remotes (e.g. origin + upstream) can switch the active remote via the `gR` keymap or `:Pipeline remote` command.